### PR TITLE
Dashboard Updates, Storage Updates

### DIFF
--- a/.env-cmdrc
+++ b/.env-cmdrc
@@ -4,7 +4,9 @@
     "REACT_APP_SERVICE_MOBILE_WALLET": "https://test.figure.tech/service-mobile-wallet/external/api/v1",
     "SKIP_PREFLIGHT_CHECK":"true",
     "REACT_APP_PROVENANCE_WALLET_PREFIX": "tp",
-    "REACT_APP_PROVENANCE_WALLET_COIN_TYPE": 1
+    "REACT_APP_PROVENANCE_WALLET_COIN_TYPE": 1,
+    "REACT_APP_LOCAL_SAVE_NAME": "provenance-web-wallet",
+    "REACT_APP_LOCAL_PASS": "provenance"
   },
   "e2e": {
     "BROWSER": "none"
@@ -17,6 +19,8 @@
     "REACT_APP_ENV": "production",
     "REACT_APP_SERVICE_MOBILE_WALLET": "https://www.figure.tech/service-mobile-wallet/external/api/v1",
     "REACT_APP_PROVENANCE_WALLET_PREFIX": "pb",
-    "REACT_APP_PROVENANCE_WALLET_COIN_TYPE": 1
+    "REACT_APP_PROVENANCE_WALLET_COIN_TYPE": 1,
+    "REACT_APP_LOCAL_SAVE_NAME": "provenance-web-wallet",
+    "REACT_APP_LOCAL_PASS": "provenance"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "Provenance Blockchain Wallet",
+  "permissions": [
+    "storage"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@testing-library/user-event": "^7.2.1",
         "@types/big.js": "6.0.2",
         "@types/chart.js": "2.9.36",
+        "@types/chrome": "0.0.181",
         "@types/create-hash": "1.2.2",
         "@types/crypto-js": "4.1.1",
         "@types/jest": "^24.9.1",
@@ -4111,6 +4112,16 @@
         "moment": "^2.10.2"
       }
     },
+    "node_modules/@types/chrome": {
+      "version": "0.0.181",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.181.tgz",
+      "integrity": "sha512-34Ln9YVVC8a195ruqWeaty3pouFdCLr9L5kPcbRflQcxnbXQnHor9uETof8OhDf8JLDytSRDiuDsRXYQYQ+9FA==",
+      "dev": true,
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "node_modules/@types/create-hash": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/create-hash/-/create-hash-1.2.2.tgz",
@@ -4141,6 +4152,21 @@
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
     },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
+      "dev": true
+    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -4164,6 +4190,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+      "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
+      "dev": true
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -28753,6 +28785,16 @@
         "moment": "^2.10.2"
       }
     },
+    "@types/chrome": {
+      "version": "0.0.181",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.181.tgz",
+      "integrity": "sha512-34Ln9YVVC8a195ruqWeaty3pouFdCLr9L5kPcbRflQcxnbXQnHor9uETof8OhDf8JLDytSRDiuDsRXYQYQ+9FA==",
+      "dev": true,
+      "requires": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "@types/create-hash": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/create-hash/-/create-hash-1.2.2.tgz",
@@ -28783,6 +28825,21 @@
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
     },
+    "@types/filesystem": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+      "dev": true,
+      "requires": {
+        "@types/filewriter": "*"
+      }
+    },
+    "@types/filewriter": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -28806,6 +28863,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/har-format": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+      "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
+      "dev": true
     },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/big.js": "6.0.2",
     "@types/chart.js": "2.9.36",
     "@types/create-hash": "1.2.2",
+    "@types/chrome":"0.0.181",
     "@types/crypto-js": "4.1.1",
     "@types/jest": "^24.9.1",
     "@types/node": "^12.20.43",

--- a/src/Components/AssetRow/AssetRow.tsx
+++ b/src/Components/AssetRow/AssetRow.tsx
@@ -1,7 +1,7 @@
 import { Sprite } from 'Components/Sprite';
 import { ICON_NAMES } from 'consts';
 import styled from 'styled-components';
-import { currencyFormat } from 'utils';
+// import { currencyFormat } from 'utils';
 
 const AssetItem = styled.div`
   padding: 20px 16px;
@@ -42,8 +42,9 @@ interface Props {
   name: string,
   onClick?: () => void,
   amount?: {
-    value: number,
-    change: number,
+    count: string,
+    value?: string,
+    change?: number,
   },
 }
 
@@ -51,8 +52,8 @@ export const AssetRow:React.FC<Props> = ({ img, name, amount, onClick }) => {
 
   const renderAmount = () => {
     if (!amount) return 'Buy • Mar 31';
-    const changeSymbol = amount.change ? '+' : '-';
-    return `${currencyFormat(amount.value)} (${changeSymbol}${amount.change})`;
+    // const changeSymbol = amount.change ? '+' : '-';
+    return amount.count;
   };
 
   return (

--- a/src/Components/CopyValue/CopyValue.tsx
+++ b/src/Components/CopyValue/CopyValue.tsx
@@ -1,0 +1,74 @@
+import { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { COLORS } from 'theme';
+
+const CopyArea = styled.div`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  position: relative;
+`;
+const CopiedNotice = styled.div`
+  background: ${COLORS.SECONDARY_650};
+  color: white;
+  position: absolute;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
+  font-size: 1.2rem;
+  font-weight: bold;
+  bottom: -30px;
+  left: -8px;
+  width: 60px;
+  box-sizing: content-box;
+  &:before {
+    content: '';
+    width: 0;
+    height: 0;
+    position: absolute;
+    top: -10px;
+    left: 30px;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-bottom: 10px solid ${COLORS.SECONDARY_650};
+  }
+`;
+
+interface Props {
+  value: string,
+  title?: string,
+  children?: React.ReactNode,
+}
+
+
+export const CopyValue:React.FC<Props> = ({ value, title = 'Copy Text', children }) => {
+  const [justCopied, setJustCopied] = useState(false);
+  const [timeoutInstance, setTimeoutInstance] = useState(0);
+
+  // Kill any times when unmounted (prevent memory leaks w/running timers)
+  useEffect(() => () => { if (timeoutInstance) { clearTimeout(timeoutInstance); } },
+    [timeoutInstance]
+  );
+
+  const handleCopyClick = () => {
+    setJustCopied(false);
+    clearTimeout(timeoutInstance);
+    navigator.clipboard.writeText(value).then(() => {
+      clearTimeout(timeoutInstance);
+      setJustCopied(true);
+      const newTimeoutInstance = window.setTimeout(() => {
+        setJustCopied(false);
+      }, 2000);
+      setTimeoutInstance(newTimeoutInstance);
+    });
+  };
+
+  return (
+    <CopyArea title={title} onClick={handleCopyClick}>
+      {children}
+      {justCopied && <CopiedNotice>Copied!</CopiedNotice>}
+    </CopyArea>
+  );
+};

--- a/src/Components/CopyValue/index.ts
+++ b/src/Components/CopyValue/index.ts
@@ -1,0 +1,1 @@
+export * from './CopyValue';

--- a/src/Components/index.ts
+++ b/src/Components/index.ts
@@ -2,6 +2,7 @@ export * from './Styled';
 export * from './Button';
 export * from './Chart';
 export * from './Checkbox';
+export * from './CopyValue';
 export * from './AssetDropdown';
 export * from './Header';
 export * from './ImageContainer';

--- a/src/Page/Asset/Asset.tsx
+++ b/src/Page/Asset/Asset.tsx
@@ -104,10 +104,10 @@ export const Asset:React.FC = () => {
       <AssetStats />
       <SectionTitle>Recent Transactions</SectionTitle>
       <div>
-        <AssetRow img="hash" name="hash" amount={{ value: 500, change: 13.63 }} />
-        <AssetRow img="hash" name="hash" amount={{ value: 500, change: 13.63 }} />
-        <AssetRow img="hash" name="hash" amount={{ value: 500, change: 13.63 }} />
-        <AssetRow img="hash" name="hash" amount={{ value: 500, change: 13.63 }} />
+        <AssetRow img="hash" name="hash" amount={{ count: '500', change: 13.63 }} />
+        <AssetRow img="hash" name="hash" amount={{ count: '500', change: 13.63 }} />
+        <AssetRow img="hash" name="hash" amount={{ count: '500', change: 13.63 }} />
+        <AssetRow img="hash" name="hash" amount={{ count: '500', change: 13.63 }} />
       </div>
       <FooterNav />
     </Wrapper>

--- a/src/Page/Create/CreateComplete.tsx
+++ b/src/Page/Create/CreateComplete.tsx
@@ -12,6 +12,7 @@ export const CreateComplete = ({ nextUrl }: Props) => {
   const finishCreation = () => {
     // Remove temp data
     clearTempWallet();
+    // Go to /dashboard
     navigate(nextUrl);
   };
   return (

--- a/src/Page/Dashboard/Dashboard.tsx
+++ b/src/Page/Dashboard/Dashboard.tsx
@@ -1,5 +1,7 @@
 import { Button, FooterNav, AssetRow } from 'Components';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAddress, useWallet } from 'redux/hooks';
 import styled from 'styled-components';
 import { DashboardHeader } from './DashboardHeader';
 
@@ -45,22 +47,45 @@ const AssetsContainer = styled.div`
 
 export const Dashboard = () => {
   const navigate = useNavigate();
+  const { getAddressAssets, assets } = useAddress();
+  const { activeWalletIndex, wallets } = useWallet();
+  const activeWallet = wallets[activeWalletIndex];
+  const { address } = activeWallet;
+
+  // Onload get account assets
+  useEffect(() => {
+    if (address) getAddressAssets(address);
+  }, [address, getAddressAssets]);
+
+  const calculatePortfolioValue = () => {
+    let totalValue = 0;
+    const assetValues = assets.map(({ usdPrice, amount }) => usdPrice * Number(amount));
+    assetValues.forEach((value) => { totalValue += value });
+    return totalValue;
+  };
+
+  const renderAssets = () => assets.map(({ display, displayAmount }) => (
+    <AssetRow
+      onClick={() => navigate(`/asset/${display}`)}
+      img={display}
+      name={display}
+      amount={{ count: displayAmount }}
+      key={display}
+    />
+  ));
 
   return (
     <>
       <DashboardHeader />
       <PortfolioTitle>Portfolio Value</PortfolioTitle>
-      <Value>$2,539.23</Value>
+      <Value>${calculatePortfolioValue().toFixed(2)}</Value>
       <ButtonGroup>
         <Button variant='primary' onClick={() => navigate('./send')}>Send</Button>
         <Button variant='primary' onClick={() => navigate('./receive')}>Receive</Button>
       </ButtonGroup>
       <AssetsTitle>My Assets</AssetsTitle>
       <AssetsContainer>
-        <AssetRow onClick={() => navigate('/asset/hash')} img="hash" name="hash" amount={{ value: 500, change: 13.63 }} />
-        <AssetRow onClick={() => navigate('/asset/usdf')} img="usdf" name="usdf" />
-        <AssetRow onClick={() => navigate('/asset/etf')} img="etf" name="etf" />
-        <AssetRow onClick={() => navigate('/asset/inu')} img="inu" name="inu" />
+        {renderAssets()}
       </AssetsContainer>
       <FooterNav />
     </>

--- a/src/Page/Dashboard/DashboardHeader.tsx
+++ b/src/Page/Dashboard/DashboardHeader.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { ICON_NAMES } from 'consts';
-import { Sprite } from 'Components';
+import { Sprite, CopyValue } from 'Components';
 import { useNavigate } from 'react-router-dom';
 import { COLORS } from 'theme';
 import { useWallet } from 'redux/hooks';
@@ -65,10 +65,12 @@ export const DashboardHeader:React.FC = () => {
       <Menu onClick={() => navigate('./menu')}>
         <Sprite icon={ICON_NAMES.MENU} size="2rem" />
       </Menu>
-      <WalletInfo>
-        <WalletName>{walletName}</WalletName>
-        <WalletAddress>({trimString(address, 11, 4)})</WalletAddress>
-      </WalletInfo>
+      <CopyValue value={address} title="Copy wallet address">
+        <WalletInfo>
+          <WalletName>{walletName}</WalletName>
+          <WalletAddress>({trimString(address, 11, 4)})</WalletAddress>
+        </WalletInfo>
+      </CopyValue>
       <WalletConnect>
         {connected ? (
           <>

--- a/src/Page/Landing/Carousel.tsx
+++ b/src/Page/Landing/Carousel.tsx
@@ -60,6 +60,9 @@ export const Carousel:React.FC = () => {
     }, (latestCurrentSlide === slideCount) ? -1 : slideTransition); // If we are looping, instantly go back to slide 1;
     // Save timer to state
     setSlideTimeout(newSlideTimeout);
+
+    // Kill any existing timers when changing page (no mem-leaks)
+    return () => { clearTimeout(slideTimeout); }
   }, [currentSlideRef, slideTimeout]);
 
   // Start auto-change slide timer
@@ -76,6 +79,7 @@ export const Carousel:React.FC = () => {
   }, [changeSlide, slideTimeout]);
   // Pull stats from API
   useEffect(() => {
+    // TODO: This needs to be cancelable to prevent memory leak when leaving landing page before load complete
     getStatistics();
   }, [getStatistics]);
 

--- a/src/Page/Landing/Landing.tsx
+++ b/src/Page/Landing/Landing.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState } from 'react';
 import { Button } from 'Components';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { getFromLocalStorage } from 'utils';
+import { getKey } from 'utils';
 import { Carousel } from './Carousel';
 
 const TextButton = styled.a`
@@ -13,25 +12,13 @@ const TextButton = styled.a`
   font-family: 'Gothic A1', sans-serif;
 `;
 
-interface LocalAccount {
-  walletName?: string,
-  key?: string,
-}
-
 export const Landing: React.FC = () => {
-  const [localAccount, setLocalAccount] = useState<LocalAccount>({});
   const navigate = useNavigate();
-
-  // On load, check to see if the user has an account in localStorage
-  useEffect(() => {
-    const localAccountData = getFromLocalStorage('provenance-web-wallet');
-    setLocalAccount(localAccountData);
-  }, []);
-
+  const savedKey = getKey();
   return (
     <>
       <Carousel />
-      {localAccount.key ? (
+      {savedKey ? (
         <Button variant="primary" onClick={() => navigate('/unlock')}>
           Unlock
         </Button>

--- a/src/Page/RequiresAuth.tsx
+++ b/src/Page/RequiresAuth.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useWallet } from 'redux/hooks';
-import { APP_URL } from 'consts';
+import { APP_URL, DASHBOARD_URL } from 'consts';
 
 interface PageProps {
   children?: React.ReactNode;
@@ -19,7 +19,10 @@ export const RequiresAuth = ({ children = null }: PageProps) => {
     if (!userAllowed) {
       navigate(APP_URL);
     }
-  }, [navigate, userAllowed]);
+    if (walletExists && isLandingPage) {
+      navigate(DASHBOARD_URL);
+    }
+  }, [navigate, userAllowed, walletExists, isLandingPage]);
 
   return (
     userAllowed ? (

--- a/src/Page/Transactions/Transactions.tsx
+++ b/src/Page/Transactions/Transactions.tsx
@@ -42,7 +42,7 @@ export const Transactions = () => {
       <Select onChange={setSelectedAsset} options={assetOptions} value={selectedAsset} />
       <Select onChange={setSelectedTxType} options={transactionOptions} value={selectedTxType} />
       <AssetsContainer>
-        <AssetRow img="hash" name="hash" amount={{ value: 500, change: 13.63 }} />
+        <AssetRow img="hash" name="hash" amount={{ count: '500', change: 13.63 }} />
         <AssetRow img="usdf" name="usdf" />
         <AssetRow img="etf" name="etf" />
         <AssetRow img="inu" name="inu" />

--- a/src/Page/UnlockAuth.tsx
+++ b/src/Page/UnlockAuth.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Outlet } from 'react-router-dom';
 import { COLORS } from 'theme';
 import { APP_URL } from 'consts';
-import { getFromLocalStorage } from 'utils';
+import { getKey } from 'utils';
 import { useNavigate } from 'react-router-dom';
 
 interface Props {
@@ -30,13 +30,12 @@ const PageStyled = styled.div<Props>`
 
 export const UnlockAuth = ({ children = null }: Props) => {
   const navigate = useNavigate();
-  const localAccountData = getFromLocalStorage('provenance-web-wallet');
-  const localAccountValid = localAccountData?.walletName && localAccountData?.key;
   useEffect(() => {
-    if (!localAccountValid) {
+    const savedKey = getKey();
+    if (!savedKey) {
       navigate(APP_URL);
     }
-  }, [localAccountValid, navigate]);
+  }, [navigate]);
 
   return (
     <PageStyled>

--- a/src/redux/features/address/addressSlice.ts
+++ b/src/redux/features/address/addressSlice.ts
@@ -87,7 +87,7 @@ const GET_ADDRESS_TX_ALL = 'GET_ADDRESS_TX_ALL';
  */
 export const getAddressAssets = createAsyncThunk(
   GET_ADDRESS_ASSETS,
-  ({ addr }: { addr: string }) =>
+  (addr: string) =>
     api({
       url: `${ADDRESS_URL}/${addr}/assets`,
     })
@@ -95,7 +95,7 @@ export const getAddressAssets = createAsyncThunk(
 
 export const getAddressTx = createAsyncThunk(
   GET_ADDRESS_TX,
-  ({ addr }: { addr: string }) =>
+  (addr: string) =>
     api({
       url: `${ADDRESS_URL}/${addr}/transactions`,
     })
@@ -103,7 +103,7 @@ export const getAddressTx = createAsyncThunk(
 
 export const getAddressTxAll = createAsyncThunk(
   GET_ADDRESS_TX_ALL,
-  ({ addr }: { addr: string }) =>
+  (addr: string) =>
     api({
       url: `${ADDRESS_URL}/${addr}/transactions/all`,
     })

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -3,7 +3,7 @@ import {
   mnemonicToSeedSync as bip39mts,
   validateMnemonic as bip39vm,
 } from 'bip39';
-import { fromSeed as bip32FromSeed, BIP32Interface } from 'bip32';
+import { fromSeed as bip32FromSeed, BIP32Interface, fromBase58 as bip32FromB58 } from 'bip32';
 import { toWords as bech32ToWords, encode as bech32Encode } from 'bech32';
 import { publicKeyCreate as secp256k1PublicKeyCreate } from 'secp256k1';
 import type { Bech32String, Bytes } from '@tendermint/types';
@@ -64,8 +64,14 @@ const createKeyPairFromMasterKey = (masterKey: BIP32Interface, path: string): Ke
   };
 }
 
-export const createWalletFromMasterKey = (masterKey: BIP32Interface, prefix: string = walletPrefix, path: string = defaultDerivationPath): Wallet => {
-  const { privateKey, publicKey } = createKeyPairFromMasterKey(masterKey, path);
+export const createWalletFromMasterKey = (
+  masterKey: BIP32Interface | string,
+  prefix: string = walletPrefix,
+  path: string = defaultDerivationPath
+): Wallet => {
+  let finalMasterKey = masterKey;
+  if (typeof masterKey === 'string') finalMasterKey = bip32FromB58(masterKey);
+  const { privateKey, publicKey } = createKeyPairFromMasterKey(finalMasterKey as BIP32Interface, path);
   const address = createAddress(publicKey, prefix);
 
   return {

--- a/src/utils/decryptPassword.ts
+++ b/src/utils/decryptPassword.ts
@@ -1,0 +1,6 @@
+import { decrypt } from './encryption';
+
+export const decryptPassword = (password: string) => {
+  if (!password) return '';
+  return decrypt(password, process.env.REACT_APP_LOCAL_PASS!);
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,6 +8,6 @@ export * from './chart';
 export * from './percentChange';
 export * from './capitalize';
 export * from './encryption';
-export * from './localStorage';
 export * from './derivationPath';
 export * from './chain';
+export * from './saveData';

--- a/src/utils/saveData.ts
+++ b/src/utils/saveData.ts
@@ -1,0 +1,80 @@
+// Determine storage type for app
+const useChromeStorage = !!window?.chrome?.storage;
+const localSaveName = process.env.REACT_APP_LOCAL_SAVE_NAME || 'provenance-web-wallet';
+
+// ----------------------
+// Session Storage
+// ----------------------
+const getSessionStorageData = (key?: string) => {
+  // Look for the item in the current localStorage, if found, add to results
+  const rawData = window.sessionStorage.getItem(localSaveName) || '{}';
+  const data = JSON.parse(rawData);
+  // If no specific key is passed, just return the entire object
+  return key ? data[key] : data;
+};
+const addSessionStorageData = (newData: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+  // Pull from localStorage
+  const rawData = window.sessionStorage.getItem(localSaveName) || '{}';
+  // Parse to edit
+  const data = JSON.parse(rawData);
+  // Update key/value
+  const finalData = {...data, ...newData};
+  // Stringify to save
+  const stringFinalData = JSON.stringify(finalData);
+  // Save
+  window.sessionStorage.setItem(localSaveName, stringFinalData);
+};
+const clearSessionStorageData = () => {
+  sessionStorage.removeItem(localSaveName);
+};
+
+// ----------------------
+// Chrome Storage
+// ----------------------
+const getChromeStorage = (key?: string) => {
+  // Speficic value
+  if (key) return chrome.storage.local.get(key, (result) => { return result })
+  // All values
+  return chrome.storage.local.get(null, (result) => { return result })
+};
+const addChromeStorage = () => {
+  console.log('TODO: addChromeStorage');
+};
+const clearChromeStorage = () => {
+  console.log('TODO: clearChromeStorage');
+};
+
+// ----------------------
+// Storage Functions
+// ----------------------
+// Get one or more values from storage
+export const getSavedData = (key?: string) => {
+  if (useChromeStorage) return getChromeStorage(key)
+  return getSessionStorageData(key);
+};
+// Add to storage
+export const addSavedData = (newData: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+  if (useChromeStorage) addChromeStorage();
+  else addSessionStorageData(newData);
+};
+// Clear out storage
+export const clearSavedData = () => {
+  if (useChromeStorage) clearChromeStorage();
+  else clearSessionStorageData();
+};
+// Special Key storage
+export const saveKey = (key: string) => {
+  const keyString = JSON.stringify({key});
+  if (useChromeStorage) console.log('saveKey Chrome');
+  else window.localStorage.setItem(localSaveName, keyString);
+}
+export const clearKey = () => {
+  if (useChromeStorage) console.log('clearKey Chrome');
+  else localStorage.removeItem(localSaveName);
+}
+export const getKey = () => {
+  if (useChromeStorage) return '';
+  const rawLocalStorageData = window?.localStorage?.getItem(localSaveName) || '';
+  const localStorageData = rawLocalStorageData ? JSON.parse(rawLocalStorageData) : {};
+  return localStorageData.key;
+}


### PR DESCRIPTION
- Add preliminary manifest for extension store.
- Update how we save data detecting either chrome storage, localStorage, or session storage.
- Save wallet password to use same password when making new accounts.
- Save key data in session storage and pull from session on load to keep session logged in
- Change to save master key instead of private wallet key (master key created from seed)
- Add ability to enter derivation when importing seed phrase (Might need updates/a revisit later)
- New copy component
- Ability to copy address from dashboard (click it)
- Fetch assets list of connected account on dashboard and display them
- Total asset values and display on dashboard.
- Update redirects when no wallet connected.
![Screen Shot 2022-04-21 at 6 27 15 PM](https://user-images.githubusercontent.com/64043462/164571619-c42792e8-af22-4c9d-b699-13525f018daf.png)
