### PR TITLE
Fix walletconnect connection bugs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,8 +4,6 @@
 ## Current Branch Tasks/Changes
 * Add "backCallback" to header component to run on click (before navigating) [DONE]
 * When leaving send flow back to dashboard, reset/clear out coin redux store data. [DONE]
-* If invalid address/unable to get gas-estimate, display an error on the next page (gas fee is required) [DONE]
-  - In "send" flow, validate the address entered
 * Move notification page redirect into App.tsx instead of RequiresAuth.tsx
 * Unable to connect [DONE]
   - Error 01: 'Session currently connected' [DONE]

--- a/TODO.md
+++ b/TODO.md
@@ -7,15 +7,14 @@
 * If invalid address/unable to get gas-estimate, display an error on the next page (gas fee is required) [DONE]
   - In "send" flow, validate the address entered
 * Move notification page redirect into App.tsx instead of RequiresAuth.tsx
-* Occationally/rarely, when clicking to connect or an action, popup opens with no content [DONE*]
-  - Hard to recreate, loads basic popup with no content (just a page background)
-* dApp connection request takes two clicks to cause popup to open [DONE*]
-  - Sometimes, not always, hard to debug/reproduce
-  - "Error: Could not establish connection. Receiving end does not exist." (first click)
-  - Look into the setting of localStorage, value changes, no popup, on second click, value exists, popup opens
-  - Potentially a walletconnect-js issue
-* Random error after/during unlock 'Error: Missing or invalid topic field' [DONE*]
-  - Unlock works, wallet exists, no other visible issues
+* Unable to connect [DONE]
+  - Error 01: 'Session currently connected' [DONE]
+    - Only happens on close (check event listener for close)
+  - Error 02: 'Uncaught (in promise) Error: Missing or invalid topic field' [DONE]
+    - Load, async chrome storage check, which checking, notification creates connector which adds it to the storage, async finishes by finding existing connection
+      - Essentially a race condition.
+      - Nothing should be allowed to happen until all initial fetch/loadings have finished
+        - Show a loading bar until that happens (add to app.tsx)
 
 ## Bugs
 * Whenever we fail to get gas estimate display error (same error as an invalid address) [1]
@@ -32,6 +31,13 @@
   - If the tab changes, reset the extension type (if not connected)
 * Sometimes extension shows pending action when there is none [3]
   - At very least, if there is none, when opened, remove pending notice from ext icon
+* Occationally/rarely, when clicking to connect or an action, popup opens with no content [DONE*MAYBE*WATCH]
+  - Hard to recreate, loads basic popup with no content (just a page background)
+* dApp connection request takes two clicks to cause popup to open [DONE*MAYBE*WATCH]
+  - Sometimes, not always, hard to debug/reproduce
+  - "Error: Could not establish connection. Receiving end does not exist." (first click)
+  - Look into the setting of localStorage, value changes, no popup, on second click, value exists, popup opens
+  - Potentially a walletconnect-js issue
 
 ## Features
 * Popup should use custom html page (instead of using index and getting js-redirected) [1]

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "Apache-2.0",
   "homepage": "/",
   "engines": {
-    "npm": ">=8.0.0 <=8.5.8",
-    "node": ">=16.0.0 <=16.15.0"
+    "npm": "8.x.x",
+    "node": "16.x.x"
   },
   "dependencies": {
     "@provenanceio/wallet-utils": "1.1.0",

--- a/public/content-script.js
+++ b/public/content-script.js
@@ -1,12 +1,10 @@
 // Add ability for dApp/website to send a message to this extension
 const sendMessage = async ({ detail }) => {
-  console.log('sendMessage() | detail: ', detail);
   await window.chrome.runtime.sendMessage(detail);
   return true;
 };
 // Initial check to make sure the extension is loaded and ready, once ready, create the event listener
 function ping() {
-  console.log('running ping()');
   window.chrome.runtime.sendMessage('ping', response => {
     if(window.chrome.runtime.lastError) {
       setTimeout(ping, 1000);

--- a/src/Page/Dashboard/DashboardConnectionDetails.tsx
+++ b/src/Page/Dashboard/DashboardConnectionDetails.tsx
@@ -30,7 +30,6 @@ export const DashboardConnectionDetails:React.FC = () => {
     connector,
     connectionEST,
     connectionEXP,
-    walletconnectDisconnect,
   } = useWalletConnect();
   const [formattedEXP, setFormattedEXP] = useState('N/A');
   const [formattedEST, setFormattedEST] = useState('N/A');
@@ -49,7 +48,7 @@ export const DashboardConnectionDetails:React.FC = () => {
   }, [navigate, connector, connected]);
 
   const handleDisconnect = () => {
-    walletconnectDisconnect();
+    if (connector) connector.killSession();
   };
 
   const renderConnectedAccounts = () => (session && session.accounts) ?

--- a/src/redux/features/account/accountSlice.ts
+++ b/src/redux/features/account/accountSlice.ts
@@ -17,6 +17,7 @@ interface ChromeInitialState {
 }
 type State = ChromeInitialState & {
   tempAccount?: TempAccount;
+  initialDataPulled: boolean;
 }
 interface UpdateTempAccount {
   payload: TempAccount
@@ -31,6 +32,7 @@ const chromeInitialState: ChromeInitialState = {
 const initialState: State = {
   ...chromeInitialState,
   tempAccount: undefined,
+  initialDataPulled: false,
 };
 
 /**
@@ -151,6 +153,7 @@ const accountSlice = createSlice({
       const { accounts, activeAccountId } = payload;
       state.accounts = accounts;
       state.activeAccountId = activeAccountId;
+      state.initialDataPulled = true;
     })
     .addCase(addAccount.fulfilled, (state, { payload }) => {
       // We won't be adding an account if it already existed in the accounts array (see async func above)

--- a/src/redux/features/settings/settingsSlice.ts
+++ b/src/redux/features/settings/settingsSlice.ts
@@ -2,12 +2,12 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { RootState } from 'redux/store';
 import { getSavedData, addSavedData, removeSavedData } from 'utils';
 import { DEFAULT_UNLOCK_DURATION } from 'consts';
-import { Settings } from 'types';
+import { SettingsState, SettingsStorage } from 'types';
 
 /**
  * TYPES
  */
-type State = Settings;
+type State = SettingsState;
 
 /**
  * STATE
@@ -16,6 +16,7 @@ const initialState: State = {
   unlockDuration: DEFAULT_UNLOCK_DURATION,
   unlockEST: 0,
   unlockEXP: 0,
+  initialDataPulled: false,
 };
 
 /**
@@ -55,7 +56,7 @@ export const resetSettingsData = createAsyncThunk(RESET_SETTINGS_DATA, async () 
   return { unlockEST, unlockEXP, unlockDuration };
 })
 // Save settings data into the chrome store
-export const saveSettingsData = createAsyncThunk(SAVE_SETTINGS_DATA, async (data: Settings) => {
+export const saveSettingsData = createAsyncThunk(SAVE_SETTINGS_DATA, async (data: SettingsStorage) => {
   // Get existing saved data (to merge into)
   const existingData = await getSavedData('settings');
   const newData = { ...existingData, ...data };
@@ -96,6 +97,7 @@ const settingsSlice = createSlice({
       state.unlockEST = unlockEST;
       state.unlockEXP = unlockEXP;
       state.unlockDuration = unlockDuration;
+      state.initialDataPulled = true;
     })
     .addCase(saveSettingsData.fulfilled, (state, { payload }) => {
       const { unlockEST, unlockEXP, unlockDuration } = payload;

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -1,5 +1,9 @@
-export interface Settings {
+export interface SettingsStorage {
   unlockEST?: number, // When was the current unlock established at
   unlockEXP?: number, // When will the current unlock expire at
   unlockDuration?: number, // How long is each unlock's lifespan
+}
+
+export type SettingsState = SettingsStorage & {
+  initialDataPulled: boolean, // On load, have we pulled all the saved settings data and added it back to redux?
 };

--- a/src/utils/saveData.ts
+++ b/src/utils/saveData.ts
@@ -1,6 +1,6 @@
 import {
   AccountStorage,
-  Settings,
+  SettingsStorage,
   WalletConnectStorage,
 } from 'types';
 
@@ -10,7 +10,7 @@ import {
 type StorageData = {} | [];
 interface StorageItems {
   account: AccountStorage,
-  settings?: Settings,
+  settings?: SettingsStorage,
   walletconnect?: WalletConnectStorage,
 };
 type StorageItemKey = keyof StorageItems;


### PR DESCRIPTION
* Add "backCallback" to header component to run on click (before navigating) [DONE]
* When leaving send flow back to dashboard, reset/clear out coin redux store data. [DONE]
* Move notification page redirect into App.tsx instead of RequiresAuth.tsx
* Unable to connect [DONE]
  - Error 01: 'Session currently connected' [DONE]
    - Only happens on close (check event listener for close)
  - Error 02: 'Uncaught (in promise) Error: Missing or invalid topic field' [DONE]
    - Load, async chrome storage check, which checking, notification creates connector which adds it to the storage, async finishes by finding existing connection
      - Essentially a race condition.
      - Nothing should be allowed to happen until all initial fetch/loadings have finished
        - Show a loading bar until that happens (add to app.tsx)