### PR TITLE
Kill Connection w/New Account

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "provenance-web-wallet-ts",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "private": true,
   "license": "Apache-2.0",
   "homepage": "/",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Provenance Blockchain Wallet",
   "description": "Provenance Blockchain Wallet Browser Extension",
   "author": "Provenance Blockchain Foundation",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "manifest_version": 3,
   "icons": {
     "16": "16.png",

--- a/public/provenance-blockchain-wallet.js
+++ b/public/provenance-blockchain-wallet.js
@@ -2,7 +2,7 @@
 (() => {
   // Provenance object
   const provenance = {
-    "version": "1.1.6", // Current extension version
+    "version": "1.1.7", // Current extension version
     isProvenance: true, // Is this the provenance extension (incase window.provenance is overwritten)
   };
   // Add provenance to global window

--- a/src/Page/NewAccount/NewAccountPassword.tsx
+++ b/src/Page/NewAccount/NewAccountPassword.tsx
@@ -3,7 +3,12 @@ import { Button, Input as InputBase, FullPage, Typo } from 'Components';
 import { PASSWORD_MIN_LENGTH } from 'consts';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { useAccount, useSettings, useActiveAccount } from 'redux/hooks';
+import {
+  useAccount,
+  useSettings,
+  useActiveAccount,
+  useWalletConnect,
+} from 'redux/hooks';
 import {
   encryptKey,
   createRootAccount,
@@ -24,6 +29,7 @@ interface Props {
 
 export const NewAccountPassword = ({ nextUrl, flowType }: Props) => {
   const navigate = useNavigate();
+  const { connector } = useWalletConnect();
   const { tempAccount, addAccount, accounts } = useAccount();
   const { bumpUnlockDuration } = useSettings();
   const [walletPassword, setWalletPassword] = useState<string[]>(['', '']); // [password, repeated-password]
@@ -108,6 +114,8 @@ export const NewAccountPassword = ({ nextUrl, flowType }: Props) => {
       // -------------------------------------------------------
       await addAccount(newAccountData);
       await bumpUnlockDuration();
+      // Since adding an account will automatically set it to active, we need to kill any previous active account connections
+      if (connector) connector.killSession();
       // Change the hash for the nextUrl
       window.location.hash = `#${nextUrl}`;
       navigate(nextUrl);

--- a/src/consts/app.ts
+++ b/src/consts/app.ts
@@ -4,5 +4,5 @@ export const PASSWORD_MIN_LENGTH = 5 as const;
 export const DEFAULT_ACCOUNT_NAME = 'Account' as const;
 export const DEFAULT_UNLOCK_DURATION = 300000 as const; // ms (5min)
 export const APP_DATA = {
-  "version": "1.1.6",
+  "version": "1.1.7",
 };


### PR DESCRIPTION
- When new account created, it will get autoswitched to active, previously wasn't killing the old accounts connection, now it will
- Version up