### PR TITLE
Existing Connection Message Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "provenance-web-wallet-ts",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "private": true,
   "license": "Apache-2.0",
   "homepage": "/",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Provenance Blockchain Wallet",
   "description": "Provenance Blockchain Wallet Browser Extension",
   "author": "Provenance Blockchain Foundation",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "manifest_version": 3,
   "icons": {
     "16": "16.png",

--- a/public/provenance-blockchain-wallet.js
+++ b/public/provenance-blockchain-wallet.js
@@ -2,7 +2,7 @@
 (() => {
   // Provenance object
   const provenance = {
-    "version": "1.1.9", // Current extension version
+    "version": "1.1.10", // Current extension version
     isProvenance: true, // Is this the provenance extension (incase window.provenance is overwritten)
   };
   // Add provenance to global window

--- a/src/Page/Notification/RequestFailed.tsx
+++ b/src/Page/Notification/RequestFailed.tsx
@@ -20,8 +20,10 @@ export const RequestFailed: React.FC<Props> = ({
 }) => {
   const [initialLoad, setInitialLoad] = useState(true);
   const { connector, removePendingRequest, bumpWCDuration } = useWalletConnect();
-  const { failedMessage = 'Unknown Error Message', title = 'Unknown Error' } =
-    pageData;
+  const {
+    failedMessage = 'Unknown Error, Please close and try again.',
+    title = 'Unknown Error',
+  } = pageData;
 
   // If we landed here, something went wrong, kill the request
   useEffect(() => {

--- a/src/consts/app.ts
+++ b/src/consts/app.ts
@@ -4,5 +4,5 @@ export const PASSWORD_MIN_LENGTH = 5 as const;
 export const DEFAULT_ACCOUNT_NAME = 'Account' as const;
 export const DEFAULT_UNLOCK_DURATION = 300000 as const; // ms (5min)
 export const APP_DATA = {
-  "version": "1.1.9",
+  "version": "1.1.10",
 };


### PR DESCRIPTION
v1.1.10
- Fixing a bug when it incorrectly thinks you're already connected to another domain.
- Version up
- Notifications now have a timeout of 3 seconds, users should never end up infinitely spinning
- Use try / catch for signMessage hex incase a normal string is passed through (must be a hex)